### PR TITLE
feat: add ai usage collect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# @okisdev/cli
+# okisdev
+
+## 0.0.3
+
+- Add `ai usage collect` command
 
 ## 0.0.2
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,16 @@
-# @okisdev/cli
+# okisdev
 
-## Usage
-
-Use the `okisdev` command to get started.
+Personal command line interface for okis.dev.
 
 ```bash
 npx okisdev <command>
 ```
 
-### `info`
+## Commands
 
-Get information about okisdev.
-
-```bash
-npx okisdev info
-```
-
-## Thanks
-
-- [shadcn/cli](https://github.com/shadcn-ui/ui)
+- `info` — print project info
+- `ai usage collect` — collect AI tool usage via `ccusage` and upload it to okis.dev (`AI_USAGE_INGEST_TOKEN`, `--dry` to preview)
 
 ## License
 
-This project is licensed under the [MIT License](./LICENSE).
+[MIT](./LICENSE)

--- a/bun.lock
+++ b/bun.lock
@@ -1,8 +1,9 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "@okisdev/cli",
+      "name": "okisdev",
       "dependencies": {
         "commander": "^13.1.0",
         "fs-extra": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okisdev",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "okisdev command line interface",
   "license": "MIT",
   "publishConfig": {

--- a/src/commands/ai.ts
+++ b/src/commands/ai.ts
@@ -1,0 +1,4 @@
+import { usage } from '@/src/commands/ai/usage';
+import { Command } from 'commander';
+
+export const ai = new Command().name('ai').description('AI usage tooling').addCommand(usage);

--- a/src/commands/ai/usage.ts
+++ b/src/commands/ai/usage.ts
@@ -1,0 +1,4 @@
+import { collect } from '@/src/commands/ai/usage/collect';
+import { Command } from 'commander';
+
+export const usage = new Command().name('usage').description('collect and publish AI tool usage').addCommand(collect);

--- a/src/commands/ai/usage/collect.ts
+++ b/src/commands/ai/usage/collect.ts
@@ -1,0 +1,169 @@
+import { execFileSync } from 'node:child_process';
+import { hostname } from 'node:os';
+import { logger } from '@/src/utils/logger';
+import { Command } from 'commander';
+
+const DEFAULT_URL = 'https://okis.dev/api/ai/usage/ingest';
+
+interface IngestDay {
+  date: string;
+  tool: string;
+  model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedTokens?: number;
+  cost?: number;
+  sessions?: number;
+}
+
+interface CollectOptions {
+  dry?: boolean;
+  url?: string;
+  token?: string;
+  machine?: string;
+  ccusage?: string;
+}
+
+interface ClaudeModelBreakdown {
+  modelName?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+  cost?: number;
+}
+
+interface ClaudeDailyItem {
+  period?: string;
+  date?: string;
+  modelBreakdowns?: ClaudeModelBreakdown[];
+}
+
+interface CodexModelValue {
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+  totalTokens?: number;
+}
+
+interface CodexDailyItem {
+  date?: string;
+  period?: string;
+  models?: Record<string, CodexModelValue>;
+  costUSD?: number;
+}
+
+function sum(...values: (number | undefined)[]) {
+  return values.reduce<number>((total, value) => total + (value ?? 0), 0);
+}
+
+function runCcusage(bin: string, args: string[]): unknown {
+  const stdout = execFileSync(bin, [...args, '--json'], {
+    encoding: 'utf8',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  return JSON.parse(stdout);
+}
+
+function claudeCodeRows(bin: string): IngestDay[] {
+  const payload = runCcusage(bin, ['daily']) as { daily?: ClaudeDailyItem[] };
+  const rows: IngestDay[] = [];
+  for (const day of payload.daily ?? []) {
+    const date = day.period ?? day.date;
+    if (!date) continue;
+    for (const model of day.modelBreakdowns ?? []) {
+      if (!model.modelName?.startsWith('claude')) continue;
+      rows.push({
+        date,
+        tool: 'claude-code',
+        model: model.modelName,
+        inputTokens: model.inputTokens ?? 0,
+        outputTokens: model.outputTokens ?? 0,
+        cachedTokens: sum(model.cacheCreationTokens, model.cacheReadTokens),
+        cost: model.cost ?? 0,
+        sessions: 0,
+      });
+    }
+  }
+  return rows;
+}
+
+function codexRows(bin: string): IngestDay[] {
+  const payload = runCcusage(bin, ['codex']) as { daily?: CodexDailyItem[] };
+  const rows: IngestDay[] = [];
+  for (const day of payload.daily ?? []) {
+    const date = day.date ?? day.period;
+    if (!date) continue;
+    const models = Object.entries(day.models ?? {});
+    const dayTokens = sum(...models.map(([, value]) => value.totalTokens)) || 1;
+    for (const [model, value] of models) {
+      rows.push({
+        date,
+        tool: 'codex',
+        model,
+        inputTokens: value.inputTokens ?? 0,
+        outputTokens: sum(value.outputTokens, value.reasoningOutputTokens),
+        cachedTokens: sum(value.cacheCreationTokens, value.cacheReadTokens),
+        cost: (day.costUSD ?? 0) * ((value.totalTokens ?? 0) / dayTokens),
+        sessions: 0,
+      });
+    }
+  }
+  return rows;
+}
+
+function collectDays(bin: string): IngestDay[] {
+  return [...claudeCodeRows(bin), ...codexRows(bin)];
+}
+
+export const collect = new Command()
+  .name('collect')
+  .description('collect AI usage via ccusage and upload it to the ingest endpoint')
+  .option('-d, --dry', 'parse and print without uploading', false)
+  .option('-u, --url <url>', 'ingest endpoint URL', process.env.AI_USAGE_INGEST_URL ?? DEFAULT_URL)
+  .option('-t, --token <token>', 'bearer token (AI_USAGE_INGEST_TOKEN)', process.env.AI_USAGE_INGEST_TOKEN)
+  .option('-m, --machine <name>', 'machine identifier', process.env.AI_USAGE_MACHINE ?? hostname())
+  .option('--ccusage <bin>', 'path to the ccusage binary', process.env.CCUSAGE_BIN ?? 'ccusage')
+  .action(async (opts: CollectOptions) => {
+    const bin = opts.ccusage ?? 'ccusage';
+    let days: IngestDay[];
+    try {
+      days = collectDays(bin);
+    } catch (error) {
+      logger.error(`failed to run ccusage: ${(error as Error).message}`);
+      logger.warn('ensure ccusage is on PATH or pass --ccusage <bin>');
+      process.exit(1);
+    }
+
+    const dry = opts.dry || !opts.token;
+    if (dry) {
+      const byTool: Record<string, number> = {};
+      for (const row of days) {
+        byTool[row.tool] = (byTool[row.tool] ?? 0) + (row.inputTokens ?? 0) + (row.outputTokens ?? 0) + (row.cachedTokens ?? 0);
+      }
+      logger.log(`machine:  ${opts.machine}`);
+      logger.log(`rows:     ${days.length}`);
+      logger.log(`tokens by tool: ${JSON.stringify(byTool)}`);
+      logger.log(`sample: ${JSON.stringify(days.slice(0, 3), null, 2)}`);
+      if (!opts.token) {
+        logger.warn('AI_USAGE_INGEST_TOKEN not set — dry run only.');
+      }
+      return;
+    }
+
+    const response = await fetch(opts.url as string, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${opts.token}`,
+      },
+      body: JSON.stringify({ machine: opts.machine, days }),
+    });
+
+    logger.log(`POST ${opts.url} -> ${response.status}`);
+    const text = await response.text();
+    if (text) logger.log(text);
+    if (!response.ok) process.exit(1);
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { ai } from '@/src/commands/ai';
 import { info } from '@/src/commands/info';
 import { Command } from 'commander';
 
@@ -15,6 +16,7 @@ async function main() {
     .version(packageJson.version || '1.0.0', '-v, --version', 'display the version number');
 
   program.addCommand(info);
+  program.addCommand(ai);
 
   program.parse();
 }


### PR DESCRIPTION
## summary

- adds `okisdev ai usage collect`, which gathers Claude Code and Codex usage via `ccusage` and uploads it to the okis.dev ingest endpoint
- config is env first, flag override: `AI_USAGE_INGEST_TOKEN`, `AI_USAGE_INGEST_URL` (default `https://okis.dev/api/ai/usage/ingest`), `AI_USAGE_MACHINE`, `CCUSAGE_BIN`; `--dry` parses and prints without uploading
- refreshes README and CHANGELOG, bumps to 0.0.3, and drops stale `@okisdev/cli` references so the package reads `okisdev` throughout

## test plan

### already verified

- [x] `tsc --noEmit` -> clean
- [x] `tsup` build -> success
- [x] `node dist/index.js ai usage collect --dry` -> 85 rows parsed from local ccusage
- [x] `CCUSAGE_BIN=/nonexistent ... collect --dry` -> graceful error and exit 1

### reviewer should verify

- [ ] `AI_USAGE_INGEST_TOKEN=... npx okisdev ai usage collect` uploads and the ingest endpoint returns `{ ok: true, upserted: N }`

## notes

- the matching `scripts/collect-ai-usage.mjs` is removed from the web repo in a separate change; this CLI replaces it