### PR TITLE
feat: collect all agents and sessions via ccusage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # okisdev
 
+## 0.0.6
+
+- Rewrite `ai usage collect` to source all agents from `ccusage daily` (Claude Code, Codex, OpenCode, Hermes, and others) instead of only Claude Code and Codex
+- Collect session counts from `ccusage session` and upload them alongside daily usage
+- Add `--since <date>` to scope a run to recent days
+
 ## 0.0.3
 
 - Add `ai usage collect` command

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npx okisdev <command>
 ## Commands
 
 - `info` — print project info
-- `ai usage collect` — collect AI tool usage via `ccusage` and upload it to okis.dev (`AI_USAGE_INGEST_TOKEN`, `--dry` to preview)
+- `ai usage collect` — collect all-agent AI usage and session counts via `ccusage` and upload them to okis.dev (`AI_USAGE_INGEST_TOKEN`, `--dry` to preview, `--since` to scope recent days)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okisdev",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "description": "okisdev command line interface",
   "license": "MIT",
   "publishConfig": {

--- a/src/commands/ai/usage/collect.ts
+++ b/src/commands/ai/usage/collect.ts
@@ -9,11 +9,17 @@ interface IngestDay {
   date: string;
   tool: string;
   model: string;
-  inputTokens?: number;
-  outputTokens?: number;
-  cachedTokens?: number;
-  cost?: number;
-  sessions?: number;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  cost: number;
+  sessions: number;
+}
+
+interface IngestSession {
+  date: string;
+  tool: string;
+  sessions: number;
 }
 
 interface CollectOptions {
@@ -22,9 +28,10 @@ interface CollectOptions {
   token?: string;
   machine?: string;
   ccusage?: string;
+  since?: string;
 }
 
-interface ClaudeModelBreakdown {
+interface ModelBreakdown {
   modelName?: string;
   inputTokens?: number;
   outputTokens?: number;
@@ -33,30 +40,25 @@ interface ClaudeModelBreakdown {
   cost?: number;
 }
 
-interface ClaudeDailyItem {
+interface DailyItem {
   period?: string;
   date?: string;
-  modelBreakdowns?: ClaudeModelBreakdown[];
+  metadata?: { agents?: string[] };
+  modelBreakdowns?: ModelBreakdown[];
 }
 
-interface CodexModelValue {
-  inputTokens?: number;
-  outputTokens?: number;
-  reasoningOutputTokens?: number;
-  cacheCreationTokens?: number;
-  cacheReadTokens?: number;
-  totalTokens?: number;
+interface SessionItem {
+  agent?: string;
+  metadata?: { lastActivity?: string };
 }
 
-interface CodexDailyItem {
-  date?: string;
-  period?: string;
-  models?: Record<string, CodexModelValue>;
-  costUSD?: number;
-}
-
-function sum(...values: (number | undefined)[]) {
+function sum(...values: (number | undefined)[]): number {
   return values.reduce<number>((total, value) => total + (value ?? 0), 0);
+}
+
+// ccusage's "claude" agent is Claude Code; keep the existing tool id so historical rows match.
+function toolForAgent(agent: string): string {
+  return agent === 'claude' ? 'claude-code' : agent;
 }
 
 function runCcusage(bin: string, args: string[]): unknown {
@@ -67,17 +69,35 @@ function runCcusage(bin: string, args: string[]): unknown {
   return JSON.parse(stdout);
 }
 
-function claudeCodeRows(bin: string): IngestDay[] {
-  const payload = runCcusage(bin, ['daily']) as { daily?: ClaudeDailyItem[] };
-  const rows: IngestDay[] = [];
-  for (const day of payload.daily ?? []) {
-    const date = day.period ?? day.date;
+function buildDays(bin: string, since?: string): IngestDay[] {
+  const args = ['daily'];
+  if (since) args.push('--since', since);
+  const payload = runCcusage(bin, args) as { daily?: DailyItem[] };
+  const items = payload.daily ?? [];
+
+  // Learn model -> agent from single-agent days (where attribution is certain),
+  // so multi-agent days can be split without a hardcoded model-prefix table.
+  const modelToAgent = new Map<string, string>();
+  for (const item of items) {
+    const agents = item.metadata?.agents ?? [];
+    if (agents.length === 1) {
+      for (const model of item.modelBreakdowns ?? []) {
+        if (model.modelName) modelToAgent.set(model.modelName, agents[0]);
+      }
+    }
+  }
+
+  const days: IngestDay[] = [];
+  for (const item of items) {
+    const date = item.period ?? item.date;
     if (!date) continue;
-    for (const model of day.modelBreakdowns ?? []) {
-      if (!model.modelName?.startsWith('claude')) continue;
-      rows.push({
+    const agents = item.metadata?.agents ?? [];
+    for (const model of item.modelBreakdowns ?? []) {
+      if (!model.modelName) continue;
+      const agent = agents.length === 1 ? agents[0] : (modelToAgent.get(model.modelName) ?? inferAgentFromModel(model.modelName) ?? 'unknown');
+      days.push({
         date,
-        tool: 'claude-code',
+        tool: toolForAgent(agent),
         model: model.modelName,
         inputTokens: model.inputTokens ?? 0,
         outputTokens: model.outputTokens ?? 0,
@@ -87,35 +107,35 @@ function claudeCodeRows(bin: string): IngestDay[] {
       });
     }
   }
-  return rows;
+  return days;
 }
 
-function codexRows(bin: string): IngestDay[] {
-  const payload = runCcusage(bin, ['codex']) as { daily?: CodexDailyItem[] };
-  const rows: IngestDay[] = [];
-  for (const day of payload.daily ?? []) {
-    const date = day.date ?? day.period;
-    if (!date) continue;
-    const models = Object.entries(day.models ?? {});
-    const dayTokens = sum(...models.map(([, value]) => value.totalTokens)) || 1;
-    for (const [model, value] of models) {
-      rows.push({
-        date,
-        tool: 'codex',
-        model,
-        inputTokens: value.inputTokens ?? 0,
-        outputTokens: sum(value.outputTokens, value.reasoningOutputTokens),
-        cachedTokens: sum(value.cacheCreationTokens, value.cacheReadTokens),
-        cost: (day.costUSD ?? 0) * ((value.totalTokens ?? 0) / dayTokens),
-        sessions: 0,
-      });
-    }
+function inferAgentFromModel(modelName: string): string | undefined {
+  if (modelName.startsWith('claude')) return 'claude';
+  if (modelName.startsWith('gpt') || modelName.startsWith('openai/') || modelName.startsWith('o1') || modelName.startsWith('o3')) return 'codex';
+  if (modelName.startsWith('glm')) return 'opencode';
+  if (modelName.startsWith('stepfun')) return 'hermes';
+  return undefined;
+}
+
+function buildSessions(bin: string, since?: string): IngestSession[] {
+  const args = ['session'];
+  if (since) args.push('--since', since);
+  const payload = runCcusage(bin, args) as { session?: SessionItem[] };
+  const counts = new Map<string, number>();
+  for (const session of payload.session ?? []) {
+    const iso = session.metadata?.lastActivity;
+    const agent = session.agent;
+    if (!iso || !agent) continue;
+    const date = iso.slice(0, 10);
+    const tool = toolForAgent(agent);
+    const key = `${date}\t${tool}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
   }
-  return rows;
-}
-
-function collectDays(bin: string): IngestDay[] {
-  return [...claudeCodeRows(bin), ...codexRows(bin)];
+  return Array.from(counts.entries()).map(([key, sessions]) => {
+    const [date, tool] = key.split('\t');
+    return { date, tool, sessions };
+  });
 }
 
 export const collect = new Command()
@@ -126,11 +146,14 @@ export const collect = new Command()
   .option('-t, --token <token>', 'bearer token (AI_USAGE_INGEST_TOKEN)', process.env.AI_USAGE_INGEST_TOKEN)
   .option('-m, --machine <name>', 'machine identifier', process.env.AI_USAGE_MACHINE ?? hostname())
   .option('--ccusage <bin>', 'path to the ccusage binary', process.env.CCUSAGE_BIN ?? 'ccusage')
+  .option('-s, --since <date>', 'only collect on or after this date (YYYY-MM-DD)', process.env.AI_USAGE_SINCE)
   .action(async (opts: CollectOptions) => {
     const bin = opts.ccusage ?? 'ccusage';
     let days: IngestDay[];
+    let sessions: IngestSession[];
     try {
-      days = collectDays(bin);
+      days = buildDays(bin, opts.since);
+      sessions = buildSessions(bin, opts.since);
     } catch (error) {
       logger.error(`failed to run ccusage: ${(error as Error).message}`);
       logger.warn('ensure ccusage is on PATH or pass --ccusage <bin>');
@@ -139,14 +162,20 @@ export const collect = new Command()
 
     const dry = opts.dry || !opts.token;
     if (dry) {
-      const byTool: Record<string, number> = {};
+      const tokensByTool: Record<string, number> = {};
       for (const row of days) {
-        byTool[row.tool] = (byTool[row.tool] ?? 0) + (row.inputTokens ?? 0) + (row.outputTokens ?? 0) + (row.cachedTokens ?? 0);
+        tokensByTool[row.tool] = (tokensByTool[row.tool] ?? 0) + row.inputTokens + row.outputTokens + row.cachedTokens;
+      }
+      const sessionsByTool: Record<string, number> = {};
+      for (const row of sessions) {
+        sessionsByTool[row.tool] = (sessionsByTool[row.tool] ?? 0) + row.sessions;
       }
       logger.log(`machine:  ${opts.machine}`);
-      logger.log(`rows:     ${days.length}`);
-      logger.log(`tokens by tool: ${JSON.stringify(byTool)}`);
-      logger.log(`sample: ${JSON.stringify(days.slice(0, 3), null, 2)}`);
+      logger.log(`days:     ${days.length}`);
+      logger.log(`sessions: ${sessions.length}`);
+      logger.log(`tokens by tool: ${JSON.stringify(tokensByTool)}`);
+      logger.log(`sessions by tool: ${JSON.stringify(sessionsByTool)}`);
+      logger.log(`sample day: ${JSON.stringify(days[0] ?? null)}`);
       if (!opts.token) {
         logger.warn('AI_USAGE_INGEST_TOKEN not set — dry run only.');
       }
@@ -159,7 +188,7 @@ export const collect = new Command()
         'content-type': 'application/json',
         authorization: `Bearer ${opts.token}`,
       },
-      body: JSON.stringify({ machine: opts.machine, days }),
+      body: JSON.stringify({ machine: opts.machine, days, sessions }),
     });
 
     logger.log(`POST ${opts.url} -> ${response.status}`);


### PR DESCRIPTION
## summary

- rewrites `ai usage collect` to source every supported agent from a single `ccusage daily` call (Claude Code, Codex, OpenCode, Hermes, and the rest) instead of only Claude Code and Codex
- attributes each model to its agent using `metadata.agents`, learning the model-to-agent map from single-agent days and falling back to a model-name prefix when a day mixes agents; `claude` keeps the `claude-code` tool id so existing rows stay consistent
- collects session counts from `ccusage session` (grouped by last-activity date and agent) and uploads them alongside daily usage; the matching web change adds a `usage_sessions` table
- uses each model's per-day cost directly from `ccusage daily` instead of approximating codex cost by token share
- adds `--since <date>` to scope a run to recent days for cron use

## test plan

### already verified

- [x] `tsc --noEmit` -> clean
- [x] `tsup` build -> success
- [x] `okisdev ai usage collect --dry` -> 92 day-rows across claude-code, codex, opencode, hermes plus 52 session rows
- [x] `okisdev ai usage collect --dry --since 2026-06-18` -> 21 day-rows, scoped correctly

### reviewer should verify

- [ ] `AI_USAGE_INGEST_TOKEN=... npx okisdev ai usage collect` uploads and the endpoint returns `{ ok: true, sessionsUpserted: N }`

## notes

- depends on the web-side `usage_sessions` table shipped in okisdev/okis.dev